### PR TITLE
feat: add one-time OAuth2 CLI for Google refresh token

### DIFF
--- a/cmd/auth/main.go
+++ b/cmd/auth/main.go
@@ -10,11 +10,14 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	gcal "google.golang.org/api/calendar/v3"
 	"golang.org/x/oauth2"
@@ -45,17 +48,43 @@ func main() {
 	// Override redirect URI to our local server.
 	cfg.RedirectURL = "http://" + localCallbackAddr + localCallbackPath
 
-	codeCh := make(chan string, 1)
+	// Generate a random CSRF state nonce to protect the callback.
+	stateBytes := make([]byte, 16)
+	if _, err := rand.Read(stateBytes); err != nil {
+		log.Fatalf("generate state nonce: %v", err)
+	}
+	csrfState := hex.EncodeToString(stateBytes)
+
+	type result struct {
+		code string
+		err  error
+	}
+	resultCh := make(chan result, 1)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc(localCallbackPath, func(w http.ResponseWriter, r *http.Request) {
+		// Handle OAuth errors (e.g., user denied consent).
+		if oauthErr := r.URL.Query().Get("error"); oauthErr != "" {
+			http.Error(w, "Authorization denied: "+oauthErr, http.StatusBadRequest)
+			resultCh <- result{err: fmt.Errorf("authorization denied: %s", oauthErr)}
+			return
+		}
+
+		// Validate CSRF state.
+		if r.URL.Query().Get("state") != csrfState {
+			http.Error(w, "invalid state", http.StatusBadRequest)
+			resultCh <- result{err: fmt.Errorf("invalid state parameter — possible CSRF")}
+			return
+		}
+
 		code := r.URL.Query().Get("code")
 		if code == "" {
 			http.Error(w, "missing code", http.StatusBadRequest)
+			resultCh <- result{err: fmt.Errorf("missing authorization code")}
 			return
 		}
 		fmt.Fprintln(w, "Auth complete — you can close this tab.")
-		codeCh <- code
+		resultCh <- result{code: code}
 	})
 
 	srv := &http.Server{Addr: localCallbackAddr, Handler: mux}
@@ -65,23 +94,39 @@ func main() {
 		}
 	}()
 
-	authURL := cfg.AuthCodeURL("state", oauth2.AccessTypeOffline, oauth2.ApprovalForce)
+	// ApprovalForce ensures Google always issues a new refresh token,
+	// even if the user has previously granted consent.
+	authURL := cfg.AuthCodeURL(csrfState, oauth2.AccessTypeOffline, oauth2.ApprovalForce)
 	fmt.Println("\nOpen this URL in your browser to authorize:")
 	fmt.Println()
 	fmt.Println(authURL)
 	fmt.Println()
 	fmt.Println("Waiting for callback on", "http://"+localCallbackAddr+localCallbackPath, "...")
 
-	code := <-codeCh
-	_ = srv.Shutdown(context.Background())
+	res := <-resultCh
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = srv.Shutdown(shutdownCtx)
 
-	token, err := cfg.Exchange(context.Background(), code)
+	if res.err != nil {
+		log.Fatalf("auth failed: %v", res.err)
+	}
+
+	token, err := cfg.Exchange(context.Background(), res.code)
 	if err != nil {
 		log.Fatalf("exchange code: %v", err)
 	}
 
+	if token.RefreshToken == "" {
+		log.Fatal("no refresh token returned by Google — revoke app access at " +
+			"https://myaccount.google.com/permissions and re-run")
+	}
+
+	out, err := json.MarshalIndent(token, "", "  ")
+	if err != nil {
+		log.Fatalf("marshal token: %v", err)
+	}
 	fmt.Println("\n--- Token details ---")
-	out, _ := json.MarshalIndent(token, "", "  ")
 	fmt.Println(string(out))
 
 	fmt.Println("\n--- Copy this into your .env ---")


### PR DESCRIPTION
## Summary

Adds a one-time OAuth2 CLI tool (`cmd/auth/main.go`) that runs the Google consent flow locally and prints the refresh token. This bootstrap utility is executed once to obtain the `GOOGLE_REFRESH_TOKEN` env var required by the server.

## Implementation

The tool:
1. Reads a `credentials.json` file from Google Cloud Console
2. Starts a local callback server on `localhost:9999`
3. Opens the browser to Google's OAuth consent URL with `AccessTypeOffline` and `ApprovalForce`
4. Captures the authorization code from the callback
5. Exchanges the code for tokens and displays the full token JSON
6. Prints the refresh token in `.env` format for easy copy-paste

## Usage

```bash
go run cmd/auth/main.go /path/to/credentials.json
```

Opens a browser, returns after user grants consent. The refresh token prints to stdout ready for `.env`.

## Testing

- [ ] Manually run against real Google credentials and verify refresh token output
- [ ] Confirm token works with `GOOGLE_REFRESH_TOKEN` env var in server

## Notes

- Credentials file required from [Google Cloud Console](https://console.cloud.google.com/)
- Scope: `https://www.googleapis.com/auth/calendar.events`
- No dependencies on server code — standalone developer utility