### PR TITLE
test: add Bruno request for explicitly named calendar event

### DIFF
--- a/bruno/create-event-named.bru
+++ b/bruno/create-event-named.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Create Event - Named
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{BASE_URL}}/event
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{BEARER_TOKEN}}
+}
+
+body:json {
+  {
+    "text": "Schedule a meeting called 'Project Review' on Friday at 2pm for 1 hour"
+  }
+}
+
+tests {
+  res.status == 201
+  res.body.event_url != ""
+}


### PR DESCRIPTION
## Summary

Adds a Bruno API request that exercises explicit event naming end-to-end. The existing `create-event-basic.bru` uses an implicit title; this new request sends text with an explicit event name (`'Project Review'`) to verify the LLM correctly extracts and passes the title through to Google Calendar.

## Changes

- Add `bruno/create-event-named.bru` with POST to `/event`, bearer auth, and assertions on status 201 and non-empty `event_url`

## Testing

- [ ] Run manually: `bruno run --env local bruno/create-event-named.bru`

## Notes

None